### PR TITLE
Update OWASP backronym: Web -> Worldwide

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Bem-vindo ao repositório oficial do capítulo OWASP de Belo Horizonte!
 
 ## Sobre
 
-O capítulo OWASP de Belo Horizonte é uma comunidade local dedicada a melhorar a segurança do software na região. Fazemos parte da [OWASP (Open Web Application Security Project)](https://owasp.org/), uma fundação sem fins lucrativos que trabalha para melhorar a segurança do software.
+O capítulo OWASP de Belo Horizonte é uma comunidade local dedicada a melhorar a segurança do software na região. Fazemos parte da [OWASP (Open Worldwide Application Security Project)](https://owasp.org/), uma fundação sem fins lucrativos que trabalha para melhorar a segurança do software.
 
 ## Missão
 


### PR DESCRIPTION

This PR has been generated by [Arkadii Yakovets](https://nest.owasp.org/members/arkid15r) based on the OWASP Board of Directors February 2023 [motion](https://board.owasp.org/meetings-historical/2023/202302.15.html) to officially change the backronym OWASP (sponsored by [Mark Curphey](https://nest.owasp.org/members/curphey) and [Avi Douglen](https://nest.owasp.org/members/avidouglen)).

>Background: Motion: "Resolved that the Foundation will change **all current and future references** of the 'Open Web Application Security Project' to the 'Open Worldwide Application Security Project'".

The purpose of this PR is to update all references to OWASP to reflect the Board approved change of the organization's name from Open **Web** Application Security Project to Open **Worldwide** Application Security Project. This ensures consistency across documentation, metadata, and project materials in alignment with the Board's decision.

For any questions or clarifications you can reach out via:

- OWASP Slack: [Arkadii Yakovets](https://owasp.slack.com/team/U060W3NKLTF)
- LinkedIn: [in/arkid15r](https://www.linkedin.com/in/arkid15r)
- BlueSky: [arkid15r.com](https://bsky.app/profile/arkid15r.com)